### PR TITLE
Add a regression test to verify the fixes introduced in #508

### DIFF
--- a/tests/test_quad_tree.py
+++ b/tests/test_quad_tree.py
@@ -19,73 +19,6 @@ class TestQuadTreeSlicer:
         self.fdbdatacube = gj.GribJump()
 
     @pytest.mark.fdb
-    def test_quad_tree_query_polygon(self):
-        points = [[10, 10], [80, 10], [-5, 5], [5, 20], [5, 10], [50, 10]]
-        slicer = QuadTreeSlicer(points)
-        polytope = Box(["lat", "lon"], [1, 1], [20, 30]).polytope()[0]
-        results = query_polygon(points, slicer.quad_tree, 0, polytope)
-        assert len(results) == 3
-        assert (10, 10) in [slicer.points[node] for node in results]
-        assert (5, 10) in [slicer.points[node] for node in results]
-        assert (5, 20) in [slicer.points[node] for node in results]
-        points = [
-            [10, 10],
-            [80, 10],
-            [-5, 5],
-            [5, 50],
-            [5, 10],
-            [50, 10],
-            [2, 10],
-            [15, 15],
-        ]
-        slicer = QuadTreeSlicer(points)
-        polytope = ConvexPolytope(["lat", "lon"], [[-10, 1], [20, 1], [5, 20]])
-        results = query_polygon(points, slicer.quad_tree, 0, polytope)
-        assert len(results) == 4
-        assert (-5, 5) in [slicer.points[node] for node in results]
-        assert (5, 10) in [slicer.points[node] for node in results]
-        assert (10, 10) in [slicer.points[node] for node in results]
-        assert (2, 10) in [slicer.points[node] for node in results]
-
-    @pytest.mark.fdb
-    def test_slice_in_two_vertically(self):
-        polytope = Box(["lat", "lon"], [0, 0], [2, 2]).polytope()[0]
-        lower, upper = slice_in_two(polytope, 1, 0)
-        assert lower.points == [[0, 0], [1.0, 0.0], [1.0, 2.0], [0, 2]]
-        assert upper.points == [[1.0, 0.0], [2, 0], [2, 2], [1.0, 2.0]]
-
-    @pytest.mark.fdb
-    def test_slice_in_two_horizontally(self):
-        polytope = Box(["lat", "lon"], [0, 0], [2, 2]).polytope()[0]
-        lower, upper = slice_in_two(polytope, 1, 1)
-        assert lower.points == [[0, 0], [2, 0], [2.0, 1.0], [0.0, 1.0]]
-        assert upper.points == [[2, 2], [0, 2], [0.0, 1.0], [2.0, 1.0]]
-
-    @pytest.mark.fdb
-    def test_quad_node_is_contained_in_box(self):
-        node = QuadNode([1, 1], 0)
-        polytope = Box(["lat", "lon"], [0, 0], [2, 2]).polytope()[0]
-        assert node.is_contained_in(polytope)
-        second_node = QuadNode([3, 3], 0)
-        assert not second_node.is_contained_in(polytope)
-        third_node = QuadNode([1, 0], 0)
-        assert third_node.is_contained_in(polytope)
-
-    @pytest.mark.fdb
-    def test_quad_node_is_contained_in_triangle(self):
-        node = QuadNode([1, 1], 0)
-        polytope = ConvexPolytope(["lat", "lon"], [[0, 0], [1, 1], [2, 0]])
-        assert node.is_contained_in(polytope)
-        node = QuadNode([1, 0.5], 0)
-        assert node.is_contained_in(polytope)
-        second_node = QuadNode([3, 3], 0)
-        assert not second_node.is_contained_in(polytope)
-        third_node = QuadNode([1, 0], 0)
-        assert third_node.is_contained_in(polytope)
-        third_node = QuadNode([0.1, 0.5], 0)
-        assert not third_node.is_contained_in(polytope)
-
-    @pytest.mark.fdb
     def test_quad_tree_slicer_extract(self):
         points = [[10, 10], [80, 10], [-5, 5], [5, 20], [5, 10], [50, 10]]
         polytope = Box(["latitude", "longitude"], [1, 1], [20, 30]).polytope()[0]
@@ -242,6 +175,69 @@ class TestQuadTreeSlicer:
 
 
 class TestQuadTreeSlicerWithoutFdb:
+    @pytest.mark.skipif(not use_rust, reason="quadtree_additional_operations targets the Rust QuadTree API")
+    def test_quad_tree_query_polygon(self):
+        points = [[10, 10], [80, 10], [-5, 5], [5, 20], [5, 10], [50, 10]]
+        slicer = QuadTreeSlicer(points)
+        polytope = Box(["lat", "lon"], [1, 1], [20, 30]).polytope()[0]
+        results = query_polygon(points, slicer.quad_tree, 0, polytope)
+        assert len(results) == 3
+        assert (10, 10) in [slicer.points[node] for node in results]
+        assert (5, 10) in [slicer.points[node] for node in results]
+        assert (5, 20) in [slicer.points[node] for node in results]
+        points = [
+            [10, 10],
+            [80, 10],
+            [-5, 5],
+            [5, 50],
+            [5, 10],
+            [50, 10],
+            [2, 10],
+            [15, 15],
+        ]
+        slicer = QuadTreeSlicer(points)
+        polytope = ConvexPolytope(["lat", "lon"], [[-10, 1], [20, 1], [5, 20]])
+        results = query_polygon(points, slicer.quad_tree, 0, polytope)
+        assert len(results) == 4
+        assert (-5, 5) in [slicer.points[node] for node in results]
+        assert (5, 10) in [slicer.points[node] for node in results]
+        assert (10, 10) in [slicer.points[node] for node in results]
+        assert (2, 10) in [slicer.points[node] for node in results]
+
+    def test_slice_in_two_vertically(self):
+        polytope = Box(["lat", "lon"], [0, 0], [2, 2]).polytope()[0]
+        lower, upper = slice_in_two(polytope, 1, 0)
+        assert lower.points == [[0, 0], [1.0, 0.0], [1.0, 2.0], [0, 2]]
+        assert upper.points == [[1.0, 0.0], [2, 0], [2, 2], [1.0, 2.0]]
+
+    def test_slice_in_two_horizontally(self):
+        polytope = Box(["lat", "lon"], [0, 0], [2, 2]).polytope()[0]
+        lower, upper = slice_in_two(polytope, 1, 1)
+        assert lower.points == [[0, 0], [2, 0], [2.0, 1.0], [0.0, 1.0]]
+        assert upper.points == [[2, 2], [0, 2], [0.0, 1.0], [2.0, 1.0]]
+
+    def test_quad_node_is_contained_in_box(self):
+        node = QuadNode([1, 1], 0)
+        polytope = Box(["lat", "lon"], [0, 0], [2, 2]).polytope()[0]
+        assert node.is_contained_in(polytope)
+        second_node = QuadNode([3, 3], 0)
+        assert not second_node.is_contained_in(polytope)
+        third_node = QuadNode([1, 0], 0)
+        assert third_node.is_contained_in(polytope)
+
+    def test_quad_node_is_contained_in_triangle(self):
+        node = QuadNode([1, 1], 0)
+        polytope = ConvexPolytope(["lat", "lon"], [[0, 0], [1, 1], [2, 0]])
+        assert node.is_contained_in(polytope)
+        node = QuadNode([1, 0.5], 0)
+        assert node.is_contained_in(polytope)
+        second_node = QuadNode([3, 3], 0)
+        assert not second_node.is_contained_in(polytope)
+        third_node = QuadNode([1, 0], 0)
+        assert third_node.is_contained_in(polytope)
+        third_node = QuadNode([0.1, 0.5], 0)
+        assert not third_node.is_contained_in(polytope)
+
     def test_extract_single_longitude_first(self):
         grid = [(4, 1), (1, 4)]  # quadtree constructor assumes points are lat/lon
         slicer = QuadTreeSlicer(grid)

--- a/tests/test_quad_tree.py
+++ b/tests/test_quad_tree.py
@@ -1,11 +1,12 @@
 import pytest
 
+from polytope_feature.datacube.backends.mock import MockDatacube
 from polytope_feature.datacube.quadtree.quad_tree import QuadNode
 from polytope_feature.datacube.quadtree.quadtree_additional_operations import (
     query_polygon,
 )
 from polytope_feature.datacube.tensor_index_tree import TensorIndexTree
-from polytope_feature.engine.quadtree_slicer import QuadTreeSlicer
+from polytope_feature.engine.quadtree_slicer import QuadTreeSlicer, use_rust
 from polytope_feature.polytope import Polytope
 from polytope_feature.shapes import Box, ConvexPolytope
 from polytope_feature.utility.geometry import slice_in_two
@@ -238,3 +239,15 @@ class TestQuadTreeSlicer:
         self.API.engines["quadtree"]._build_sliceable_child(polytope, lat_ax, tree, self.API.datacube, [], None)
         print(time.time() - time1)
         assert len(tree.leaves) == 55100
+
+
+class TestQuadTreeSlicerWithoutFdb:
+    def test_extract_single_longitude_first(self):
+        grid = [(4, 1), (1, 4)]  # quadtree constructor assumes points are lat/lon
+        slicer = QuadTreeSlicer(grid)
+        polytope = Box(["longitude", "latitude"], [0, 2], [3, 5]).polytope()[0]
+        found = {
+            slicer.points[point if use_rust else point.index]
+            for point in slicer.extract_single(MockDatacube({}), polytope)
+        }
+        assert found == {(4, 1)}


### PR DESCRIPTION
### Description

This PR modifies `test_quad_tree.py` to
- create a new class `TestQuadTreeSlicerWithoutFdb` for tests that don't require an FDB datacube,
- adds a regression test `test_extract_single_longitude_first` to verify the bugfix introduced in #508, and
- move the remaining tests that don't depend on FDB to the new class.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
